### PR TITLE
base: Add special captive portal servers for chinese

### DIFF
--- a/services/core/java/com/android/server/connectivity/NetworkMonitor.java
+++ b/services/core/java/com/android/server/connectivity/NetworkMonitor.java
@@ -26,6 +26,7 @@ import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
+import android.content.res.Resources;
 import android.net.CaptivePortal;
 import android.net.ConnectivityManager;
 import android.net.ICaptivePortal;
@@ -79,6 +80,8 @@ import java.util.List;
 import java.util.Random;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.text.DecimalFormat;
+import java.util.Locale;
 
 /**
  * {@hide}
@@ -101,9 +104,13 @@ public class NetworkMonitor extends StateMachine {
                                                       + "AppleWebKit/537.36 (KHTML, like Gecko) "
                                                       + "Chrome/60.0.3112.32 Safari/537.36";
 
+    private static final String DEFAULT_HTTPS_URL_CN     = "https://captive.v2ex.co/generate_204";
+    private static final String DEFAULT_HTTP_URL_CN      = "http://captive.v2ex.co/generate_204";
+    private static final String DEFAULT_FALLBACK_URL_CN  = "http://g.cn/generate_204";
+
     private static final int SOCKET_TIMEOUT_MS = 10000;
     private static final int PROBE_TIMEOUT_MS  = 3000;
-
+ 
     static enum EvaluationResult {
         VALIDATED(true),
         CAPTIVE_PORTAL(false);
@@ -704,19 +711,28 @@ public class NetworkMonitor extends StateMachine {
             return addressByFamily.values().toArray(new InetAddress[addressByFamily.size()]);
         }
     }
+    
+    private static boolean isChinese() {
+        Locale locale = Resources.getSystem().getConfiguration().locale;
+        return locale.getLanguage().startsWith(Locale.CHINESE.getLanguage())
+                && !locale.getCountry().equals("TW");
+    }
+
 
     private static String getCaptivePortalServerHttpsUrl(Context context) {
-        return getSetting(context, Settings.Global.CAPTIVE_PORTAL_HTTPS_URL, DEFAULT_HTTPS_URL);
+        return getSetting(context, Settings.Global.CAPTIVE_PORTAL_HTTPS_URL,
+                         isChinese() ? DEFAULT_HTTPS_URL_CN : DEFAULT_HTTPS_URL);
     }
 
     public static String getCaptivePortalServerHttpUrl(Context context) {
-        return getSetting(context, Settings.Global.CAPTIVE_PORTAL_HTTP_URL, DEFAULT_HTTP_URL);
+        return getSetting(context, Settings.Global.CAPTIVE_PORTAL_HTTP_URL,
+                         isChinese() ? DEFAULT_HTTP_URL_CN : DEFAULT_HTTP_URL);
     }
 
     private URL[] makeCaptivePortalFallbackUrls(Context context) {
         String separator = ",";
         String firstUrl = getSetting(context,
-                Settings.Global.CAPTIVE_PORTAL_FALLBACK_URL, DEFAULT_FALLBACK_URL);
+                Settings.Global.CAPTIVE_PORTAL_FALLBACK_URL, isChinese() ? DEFAULT_FALLBACK_URL_CN : DEFAULT_FALLBACK_URL);
         String joinedUrls = firstUrl + separator + getSetting(context,
                 Settings.Global.CAPTIVE_PORTAL_OTHER_FALLBACK_URLS, DEFAULT_OTHER_FALLBACK_URLS);
         List<URL> urls = new ArrayList<>();


### PR DESCRIPTION
as we all know,google.com has been banned in China. So we who are in China cant
connect to the CaptivePortal server,then All networks (wifi, mobile data) are mistakenly
detected as having no network connection
This solution sets the appropriate server by detecting the system default language

Signed-off-by: fatesay <dmf040619@163.com>