### PR TITLE
SystemUI: Fix too big spacing between QS icons in landscape on sw600dp

### DIFF
--- a/libs/hwui/Android.bp
+++ b/libs/hwui/Android.bp
@@ -32,9 +32,7 @@ cc_defaults {
         // TODO: Linear blending should be enabled by default, but we are
         // TODO: making it an opt-in while it's a work in progress
         //"-DANDROID_ENABLE_LINEAR_BLENDING",
-        
     ],
-    ldflags: [],
 
     include_dirs: [
         "external/skia/include/private",
@@ -51,8 +49,6 @@ cc_defaults {
             cflags: ["-DUSE_HWC2"],
         },
     },
-
-    quicksilver: true,
 }
 
 cc_defaults {

--- a/packages/SystemUI/res/values-sw600dp/dimens.xml
+++ b/packages/SystemUI/res/values-sw600dp/dimens.xml
@@ -16,6 +16,9 @@
 */
 -->
 <resources>
+    <!-- Width for the spacer, used between QS tiles. -->
+    <dimen name="qs_quick_tile_space_width">0dp</dimen>
+
     <!-- Standard notification width + gravity -->
     <dimen name="notification_panel_width">@dimen/standard_notification_panel_width</dimen>
 


### PR DESCRIPTION
Change-Id: I047453c169854636d9e179d4678b94c7724bb854