### PR TITLE
Fix automatic day/night mode in Car Mode

### DIFF
--- a/core/res/res/values/config.xml
+++ b/core/res/res/values/config.xml
@@ -922,7 +922,7 @@
     <!--  Control whether to lock day/night mode change from normal application. When it is
           true, day / night mode change is only allowed to apps with MODIFY_DAY_NIGHT_MODE
           permission. -->
-    <bool name="config_lockDayNightMode">true</bool>
+    <bool name="config_lockDayNightMode">false</bool>
 
     <!-- Control the default night mode to use when there is no other mode override set.
          One of the following values (see UiModeManager.java):

--- a/packages/SystemUI/res/layout/status_bar.xml
+++ b/packages/SystemUI/res/layout/status_bar.xml
@@ -69,6 +69,7 @@
                 android:id="@+id/status_bar_left_side"
                 android:layout_height="match_parent"
                 android:layout_width="match_parent"
+                android:orientation="horizontal"
                 android:clipChildren="false"
             >
 
@@ -78,7 +79,6 @@
                     android:layout_height="match_parent"
                     android:textAppearance="@style/TextAppearance.StatusBar.Clock"
                     android:singleLine="true"
-                    android:visibility="gone"
                     android:paddingStart="@dimen/status_bar_left_clock_starting_padding"
                     android:paddingEnd="@dimen/status_bar_left_clock_end_padding"
                     android:gravity="center_vertical|start"
@@ -127,7 +127,7 @@
             android:id="@+id/cutout_space_view"
             android:layout_width="0dp"
             android:layout_height="match_parent"
-            android:gravity="center_horizontal|center_vertical"
+            android:gravity="center"
         />
 
         <com.android.keyguard.AlphaOptimizedLinearLayout android:id="@+id/system_icon_area"
@@ -135,11 +135,19 @@
             android:layout_height="match_parent"
             android:layout_weight="@integer/system_icon_area_weight"
             android:orientation="horizontal"
-            android:gravity="center_vertical|end"
+            android:gravity="end|center"
             >
 
             <include layout="@layout/system_icons" />
         </com.android.keyguard.AlphaOptimizedLinearLayout>
+
+        <ViewStub
+            android:id="@+id/ticker_stub"
+            android:inflatedId="@+id/ticker"
+            android:layout="@layout/status_bar_ticker"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+        />
 
         <com.android.systemui.statusbar.policy.ClockRight
             android:id="@+id/right_clock"
@@ -172,14 +180,6 @@
             android:singleLine="true"
             />
     </com.android.keyguard.AlphaOptimizedLinearLayout>
-
-    <ViewStub
-        android:id="@+id/ticker_stub"
-        android:inflatedId="@+id/ticker"
-        android:layout="@layout/status_bar_ticker"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-    />
 
     <ViewStub
         android:id="@+id/emergency_cryptkeeper_text"

--- a/packages/SystemUI/src/com/android/systemui/statusbar/phone/StatusBar.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/phone/StatusBar.java
@@ -4775,7 +4775,15 @@ public class StatusBar extends SystemUI implements DemoMode,
         boolean useGlassyTheme = false;
 
         haltTicker();
-
+        
+        final boolean deviceInCarMode = umm.getCurrentModeType() == Configuration.UI_MODE_TYPE_CAR;
+        
+        if (deviceInCarMode) {
+            mUiOffloadThread.submit(() -> {
+                umm.setNightMode(UiModeManager.MODE_NIGHT_AUTO);
+            });
+        }
+        
         if (mCurrentTheme == 0) {
             // The system wallpaper defines if QS should be light or dark.
             final WallpaperColors systemColors = mColorExtractor.getWallpaperColors(WallpaperManager.FLAG_SYSTEM);
@@ -4793,7 +4801,7 @@ public class StatusBar extends SystemUI implements DemoMode,
             useGlassyTheme = mCurrentTheme == 4;
         }
 
-        if (isUsingDarkTheme() == false && isUsingShadyTheme() == false && isUsingGlassyTheme() == false) {
+        if (isUsingDarkTheme() == false && isUsingShadyTheme() == false && isUsingGlassyTheme() == false && !deviceInCarMode) {
             mUiOffloadThread.submit(() -> {
                 umm.setNightMode(UiModeManager.MODE_NIGHT_NO);
             });
@@ -4806,7 +4814,10 @@ public class StatusBar extends SystemUI implements DemoMode,
             unfuckBlackWhiteAccent();
             mUiOffloadThread.submit(() -> {
                 ThemeAccentUtils.setLightDarkTheme(mOverlayManager, mLockscreenUserManager.getCurrentUserId(), useDark);
-                umm.setNightMode(UiModeManager.MODE_NIGHT_YES);
+                
+                if (!deviceInCarMode) {
+                    umm.setNightMode(UiModeManager.MODE_NIGHT_YES);
+                }
             });
         }
 
@@ -4817,7 +4828,9 @@ public class StatusBar extends SystemUI implements DemoMode,
             unfuckBlackWhiteAccent();
             mUiOffloadThread.submit(() -> {
                 ThemeAccentUtils.setShadyTheme(mOverlayManager, mLockscreenUserManager.getCurrentUserId(), useShady);
-                umm.setNightMode(UiModeManager.MODE_NIGHT_YES);
+                if (!deviceInCarMode) {
+                    umm.setNightMode(UiModeManager.MODE_NIGHT_YES);
+                }
             });
         }
 
@@ -4828,7 +4841,9 @@ public class StatusBar extends SystemUI implements DemoMode,
             unfuckBlackWhiteAccent();
             mUiOffloadThread.submit(() -> {
                 ThemeAccentUtils.setGlassyTheme(mOverlayManager, mLockscreenUserManager.getCurrentUserId(), useGlassy);
-                umm.setNightMode(UiModeManager.MODE_NIGHT_YES);
+                if (!deviceInCarMode) {
+                    umm.setNightMode(UiModeManager.MODE_NIGHT_YES);
+                }
             });
         }
 


### PR DESCRIPTION
The new theme engine sets up a fixed day / night mode, even when the device is docked or connected to Android Auto.

This commit solves the issue by setting the day/night mode to automatic when the phone switch the UI mode to car mode.

Also by locking the day/night mode, Android Auto cannot switch between modes automatically because Google doesn't declare the permission, yet. I've restored the setting and didn't notice any issues for the past few days of usage.