### PR TITLE
Try to fix non-digital clocks not refreshing in AOD

### DIFF
--- a/core/java/android/provider/Settings.java
+++ b/core/java/android/provider/Settings.java
@@ -6662,6 +6662,12 @@ public final class Settings {
         public static final String WEATHER_LOCKSCREEN_ENABLED = "weather_lockscreen_enabled";
 
         /**
+         * Use doubletap as doze pulse triggers
+         * @hide
+         */
+        public static final String DOZE_TRIGGER_DOUBLETAP = "doze_trigger_doubletap";
+
+        /**
          * Settings to backup. This is here so that it's in the same place as the settings
          * keys and easy to update.
          *

--- a/libs/hwui/Android.bp
+++ b/libs/hwui/Android.bp
@@ -32,9 +32,7 @@ cc_defaults {
         // TODO: Linear blending should be enabled by default, but we are
         // TODO: making it an opt-in while it's a work in progress
         //"-DANDROID_ENABLE_LINEAR_BLENDING",
-        
     ],
-    ldflags: [],
 
     include_dirs: [
         "external/skia/include/private",
@@ -51,8 +49,6 @@ cc_defaults {
             cflags: ["-DUSE_HWC2"],
         },
     },
-
-    quicksilver: true,
 }
 
 cc_defaults {

--- a/packages/SystemUI/src/com/android/keyguard/KeyguardStatusView.java
+++ b/packages/SystemUI/src/com/android/keyguard/KeyguardStatusView.java
@@ -433,6 +433,20 @@ public class KeyguardStatusView extends GridLayout implements
         } else if (mClockSelection == 11) {
             mClockView.setFormat12Hour(Html.fromHtml("<strong>h</strong><font color=" + getResources().getColor(R.color.sammy_minutes_accent) + ">mm</font>"));
             mClockView.setFormat24Hour(Html.fromHtml("<strong>kk</strong><font color=" + getResources().getColor(R.color.sammy_minutes_accent) + ">mm</font>"));
+        } else if (mClockSelection == 2) {
+            mCustomClockView.onTimeChanged();
+        } else if (mClockSelection == 7) {
+            mSpideyClockView.onTimeChanged();
+        } else if (mClockSelection == 8) {
+            mCustomNumClockView.onTimeChanged();
+        } else if (mClockSelection == 12) {
+            mDotClockView.onTimeChanged();
+        } else if (mClockSelection == 13) {
+            mSpectrumClockView.onTimeChanged();
+        } else if (mClockSelection == 14) {
+            mSneekyClockView.onTimeChanged();
+        } else if (mClockSelection == 15) {
+            mTextClock.onTimeChanged();
         } else {
             mClockView.setFormat12Hour("hh\nmm");
             mClockView.setFormat24Hour("kk\nmm");
@@ -1332,6 +1346,7 @@ public class KeyguardStatusView extends GridLayout implements
 		mDotClockView.setDark(dark);
         mSpectrumClockView.setDark(dark);
         mSneekyClockView.setDark(dark);
+	mTextClock.setTextColor(blendedTextColor);
         updateVisibilities();
     }
 

--- a/packages/SystemUI/src/com/android/keyguard/clocks/CustomAnalogClock.java
+++ b/packages/SystemUI/src/com/android/keyguard/clocks/CustomAnalogClock.java
@@ -256,7 +256,7 @@ public class CustomAnalogClock extends View {
         }
     }
 
-    private void onTimeChanged() {
+    public void onTimeChanged() {
         mCalendar.setToNow();
 
         int hour = mCalendar.hour;

--- a/packages/SystemUI/src/com/android/keyguard/clocks/CustomTextClock.java
+++ b/packages/SystemUI/src/com/android/keyguard/clocks/CustomTextClock.java
@@ -142,7 +142,7 @@ public class CustomTextClock extends TextView {
         refreshLockFont();
     }
 
-    private void onTimeChanged() {
+    public void onTimeChanged() {
         mCalendar.setToNow();
         h24 = DateFormat.is24HourFormat(getContext());
 


### PR DESCRIPTION
Currently non-digital clocks (analog and text) are not refreshing in AOD when the phone is in deep sleep. I think this is due to `refreshTime` only calling `mClockView.refresh`. Attempt to fix this by calling `onTimeChanged` for other clocks in `refreshTime`.

@skulshady I don't have a building machine so can't test this. Maybe you can merge it in the next build and if it doesn't work, you can revert it. I don't think merging this will cause any problems.