### PR TITLE
Fix analog clocks not refreshing in AOD 

### DIFF
--- a/libs/hwui/Android.bp
+++ b/libs/hwui/Android.bp
@@ -32,9 +32,7 @@ cc_defaults {
         // TODO: Linear blending should be enabled by default, but we are
         // TODO: making it an opt-in while it's a work in progress
         //"-DANDROID_ENABLE_LINEAR_BLENDING",
-        
     ],
-    ldflags: [],
 
     include_dirs: [
         "external/skia/include/private",
@@ -51,8 +49,6 @@ cc_defaults {
             cflags: ["-DUSE_HWC2"],
         },
     },
-
-    quicksilver: true,
 }
 
 cc_defaults {

--- a/packages/SystemUI/src/com/android/keyguard/KeyguardStatusView.java
+++ b/packages/SystemUI/src/com/android/keyguard/KeyguardStatusView.java
@@ -433,7 +433,19 @@ public class KeyguardStatusView extends GridLayout implements
         } else if (mClockSelection == 11) {
             mClockView.setFormat12Hour(Html.fromHtml("<strong>h</strong><font color=" + getResources().getColor(R.color.sammy_minutes_accent) + ">mm</font>"));
             mClockView.setFormat24Hour(Html.fromHtml("<strong>kk</strong><font color=" + getResources().getColor(R.color.sammy_minutes_accent) + ">mm</font>"));
-        } else if (mClockSelection == 15) {
+        } else if (mClockSelection == 2) {
+            mCustomClockView.onTimeChanged();
+        } else if (mClockSelection == 7) {
+            mSpideyClockView.onTimeChanged();
+        } else if (mClockSelection == 8) {
+            mCustomNumClockView.onTimeChanged();
+        } else if (mClockSelection == 12) {
+            mDotClockView.onTimeChanged();
+        } else if (mClockSelection == 13) {
+            mSpectrumClockView.onTimeChanged();
+        } else if (mClockSelection == 14) {
+            mSneekyClockView.onTimeChanged();
+	} else if (mClockSelection == 15) {
             mTextClock.onTimeChanged();
         } else {
             mClockView.setFormat12Hour("hh\nmm");

--- a/packages/SystemUI/src/com/android/keyguard/clocks/CustomAnalogClock.java
+++ b/packages/SystemUI/src/com/android/keyguard/clocks/CustomAnalogClock.java
@@ -256,7 +256,7 @@ public class CustomAnalogClock extends View {
         }
     }
 
-    private void onTimeChanged() {
+    public void onTimeChanged() {
         mCalendar.setToNow();
 
         int hour = mCalendar.hour;


### PR DESCRIPTION
Currently analog clocks are not refreshing in AOD when the phone is in deep sleep. Based on the fix for TextClock.

Also make onTimeChanged in CustomAnalogClock public so refreshTime in KeyguardStatusView can call it.