### PR TITLE
Remove KEYCODE_CAMERA from navigation category

### DIFF
--- a/services/core/java/com/android/server/policy/NavbarUtilities.java
+++ b/services/core/java/com/android/server/policy/NavbarUtilities.java
@@ -98,8 +98,7 @@ public class NavbarUtilities {
             KeyEvent.KEYCODE_BACK,
             KeyEvent.KEYCODE_MENU,
             KeyEvent.KEYCODE_ASSIST,
-            KeyEvent.KEYCODE_APP_SWITCH,
-            KeyEvent.KEYCODE_CAMERA
+            KeyEvent.KEYCODE_APP_SWITCH
     };
 
     /**
@@ -143,8 +142,6 @@ public class NavbarUtilities {
                 return com.android.internal.R.integer.config_doubleTapOnAssistKeyBehavior;
             case KeyEvent.KEYCODE_APP_SWITCH:
                 return com.android.internal.R.integer.config_doubleTapOnAppSwitchKeyBehavior;
-            case KeyEvent.KEYCODE_CAMERA:
-                return com.android.internal.R.integer.config_doubleTapOnCameraKeyBehavior;
         }
         return 0;
     }
@@ -165,8 +162,6 @@ public class NavbarUtilities {
                 return com.android.internal.R.integer.config_longPressOnAssistKeyBehavior;
             case KeyEvent.KEYCODE_APP_SWITCH:
                 return com.android.internal.R.integer.config_longPressOnAppSwitchKeyBehavior;
-            case KeyEvent.KEYCODE_CAMERA:
-                return com.android.internal.R.integer.config_longPressOnCameraKeyBehavior;
         }
         return 0;
     }


### PR DESCRIPTION
Having camera keycode in navigation category prevents the dispatching of the key event. Hence, not handling the camera button.

#### Prevented dispatching from here: https://github.com/Havoc-OS/android_frameworks_base/blob/b13ccc6ad3df3dd2ad5348f68f34dad2acffb612/services/core/java/com/android/server/policy/PhoneWindowManager.java#L4449

#### Because of returned `true` from: https://github.com/Havoc-OS/android_frameworks_base/blob/b13ccc6ad3df3dd2ad5348f68f34dad2acffb612/services/core/java/com/android/server/policy/NavbarUtilities.java#L178

#### At the end being: https://github.com/Havoc-OS/android_frameworks_base/blob/b13ccc6ad3df3dd2ad5348f68f34dad2acffb612/services/core/java/com/android/server/policy/NavbarUtilities.java#L102

With the change in this PR, camera keycode will be dispatched as intended BUT the implementation of handling this key event will vary. Either separate device key handler, or lineage's camera button commit.

----

#### This commit is definitely not the final solution because of overlays and preferences being showed in `Configuration Center`