### PR TITLE
Camera: Expose aux camera if package name is null

### DIFF
--- a/core/java/android/hardware/Camera.java
+++ b/core/java/android/hardware/Camera.java
@@ -273,6 +273,8 @@ public class Camera {
          * if the package name does not falls in this bucket
          */
         String packageName = ActivityThread.currentOpPackageName();
+                if (packageName == null)
+            return true;
         List<String> packageList = new ArrayList<>(Arrays.asList(
                 SystemProperties.get("vendor.camera.aux.packagelist", ",").split(",")));
         List<String> packageExcludelist = new ArrayList<>(Arrays.asList(


### PR DESCRIPTION
In case of the package name not being found properly the name would always be found in the excludelist, even if the list is empty. This leads to denying aux camera access in some cases where it is not intended to be blocked.