### PR TITLE
camera2: Add non burst sizes to mandatory streams for ultra high reso…

### DIFF
--- a/core/java/android/hardware/camera2/params/MandatoryStreamCombination.java
+++ b/core/java/android/hardware/camera2/params/MandatoryStreamCombination.java
@@ -1699,7 +1699,17 @@ public final class MandatoryStreamCombination {
                 }
 
                 if (isUltraHighResolution) {
-                    sizes.add(getMaxSize(sm.getOutputSizes(formatChosen)));
+                    Size [] outputSizes = sm.getOutputSizes(formatChosen);
+                    Size [] highResolutionOutputSizes =
+                            sm.getHighResolutionOutputSizes(formatChosen);
+                    Size maxBurstSize = getMaxSizeOrNull(outputSizes);
+                    Size maxHighResolutionSize = getMaxSizeOrNull(highResolutionOutputSizes);
+                    Size chosenMaxSize =
+                            maxBurstSize != null ? maxBurstSize : maxHighResolutionSize;
+                    if (maxBurstSize != null && maxHighResolutionSize != null) {
+                        chosenMaxSize = getMaxSize(maxBurstSize, maxHighResolutionSize);
+                    }
+                    sizes.add(chosenMaxSize);
                 } else {
                     if (formatChosen == ImageFormat.RAW_SENSOR) {
                         // RAW_SENSOR always has MAXIMUM threshold.
@@ -2099,6 +2109,20 @@ public final class MandatoryStreamCombination {
             }
 
             return sz;
+        }
+        /**
+         * Get the largest size by area.
+         *
+         * @param sizes an array of sizes
+         *
+         * @return Largest Size or null if sizes was null or had 0 elements
+         */
+        public static @Nullable Size getMaxSizeOrNull(Size... sizes) {
+            if (sizes == null || sizes.length == 0) {
+                return null;
+            }
+
+            return getMaxSize(sizes);
         }
 
         /**


### PR DESCRIPTION
Bug: 240128812

Test: Vendor testing
Test: RobustnessTest.java on cuttlefish

Change-Id: I92047456a43d49c5354718ead10df2cbd60363e2
Signed-off-by: Jayant Chowdhary <jchowdhary@google.com>
Signed-off-by: Pranav Vashi <neobuddy89@gmail.com>
Signed-off-by: DennySPb <dennyspb@gmail.com>
Signed-off-by: chandu078 <chandudyavanapelli03@gmail.com>
(cherry picked from commit 3ae98e4)