### PR TITLE
camera: Add backwards-compatible CaptureResultExtras constructor

### DIFF
--- a/core/java/android/hardware/camera2/impl/CaptureResultExtras.java
+++ b/core/java/android/hardware/camera2/impl/CaptureResultExtras.java
@@ -74,7 +74,20 @@ public class CaptureResultExtras implements Parcelable {
     public int describeContents() {
         return 0;
     }
-
+    // Backwards-compatible constructor
+    public CaptureResultExtras(int requestId, int subsequenceId, int afTriggerId,
+                               int precaptureTriggerId, long frameNumber,
+                               int partialResultCount, int errorStreamId,
+                               String errorPhysicalCameraId, long lastCompletedRegularFrameNumber,
+                               long lastCompletedReprocessFrameNumber,
+                               long lastCompletedZslFrameNumber) {
+        this(requestId, subsequenceId, afTriggerId, precaptureTriggerId, frameNumber,
+                partialResultCount, errorStreamId, errorPhysicalCameraId,
+                lastCompletedRegularFrameNumber, lastCompletedReprocessFrameNumber,
+                lastCompletedZslFrameNumber,
+                false /*hasReadOutTimestamp*/, 0 /*readoutTimestamp*/);
+    }
+    
     @Override
     public void writeToParcel(Parcel dest, int flags) {
         dest.writeInt(requestId);


### PR DESCRIPTION
Commit https://github.com/PixelExperience/frameworks_base/commit/e16fed203aaf99e8578e42feb43c21ad2ad47a68 added readout timestamp parameters which changed the constructor, but is unsupported by few stock camera apps, such as MIUI Camera.